### PR TITLE
Fix dependencies to build with cabal

### DIFF
--- a/eetc/cabal.project
+++ b/eetc/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/eetc/default.nix
+++ b/eetc/default.nix
@@ -15,8 +15,8 @@ let
               unbound-generics =
                 let unbound-src =
                       pkgs.fetchzip {
-                        url = "https://github.com/lambdageek/unbound-generics/archive/a2a558058012b09bb313b3eb03cddb734fcf4a98.zip";
-                        sha256 = "af4592a93d0d280591b3bcff3ebe244956cc3637bf20ed2315fb6b2e070caef4";
+                        url = "https://github.com/lambdageek/unbound-generics/archive/bd9bac1242ecb62d8152efc0e36357f2e1563fc5.zip";
+                        sha256 = "sha256-2naqNNVZ13XDPoCJD3JU8JNVOTi9WCFfTRAnSVyVxY0=";
   };
                 in haskellPackagesNew.callCabal2nix "unbound-generics" unbound-src {};
             };
@@ -28,4 +28,4 @@ let
 in
 { compiler ? "ghc922",
   nixpkgs ? import defpkgs {config = (config compiler);} }:
-nixpkgs.pkgs.haskell.packages."${compiler}".callCabal2nix "eetc" ./. {}
+nixpkgs.pkgs.haskell.packages."${compiler}".callCabal2nixWithOptions "eetc" ./. "--no-check" {}

--- a/eetc/eetc.cabal
+++ b/eetc/eetc.cabal
@@ -47,9 +47,10 @@ common shared-properties
   build-depends:
     base >= 4 && < 5,
     parsec >= 3.1.8 && < 3.2,
-    mtl >= 2.2.1,
+    mtl >= 2.2.1 && < 2.3,
     pretty >= 1.0.1.0,
-    unbound-generics >= 0.2,
+    unbound-generics >= 0.4.3,
+      -- method Unbound.Generics.LocallyNameless.Subst.Subst.substBvs was added in 0.4.3
     transformers,
     array >= 0.3.0.2 && < 0.6,
     -- monad-control-1.0.1.0 is the first to contain liftThrough

--- a/eetc/stack.yaml
+++ b/eetc/stack.yaml
@@ -1,15 +1,15 @@
-resolver: lts-18.28
+resolver: lts-20.18
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
 
 extra-deps:
-- git: git@github.com:lambdageek/unbound-generics.git
-  commit: a2a558058012b09bb313b3eb03cddb734fcf4a98
+- unbound-generics-0.4.3
+# - git: git@github.com:lambdageek/unbound-generics.git
+#   commit: a2a558058012b09bb313b3eb03cddb734fcf4a98
 
 
 flags: {}
 
 extra-package-dbs: []
-


### PR DESCRIPTION
I managed to build this with `cabal`, after some restrictions placed on dependencies.

However, the testsuite is broken (`cabal test`), and also the examples in `pi` all failed to type-check.